### PR TITLE
Hotfix for broken social link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fayhen.github.io",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Fayhen's Quasar curriculum",
   "productName": "Diego Souza",
   "author": "Diego Garcia Cordeiro Souza <diego00alfa@gmail.com>",

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -61,7 +61,7 @@
             />
           </a>
           <a
-            href="www.linkedin.com/in/diegogcsouza"
+            href="https://www.linkedin.com/in/diegogcsouza/"
             target="_blank"
             rel="noopener noreferrer"
             style="text-decoration: none; color: inherit;"


### PR DESCRIPTION
Bumped version 1.0.3 -> 1.0.4. Fixed a broken social link in `MainLayout.vue`.